### PR TITLE
Fix readme typos and remove broken whiteboard URLs from TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 --------------------------
 
-# This is my collection of data structures, algorithms and code challenges. Please visit the [Table of Contents](./table_of_contents.md) to view all the categories. Within each catagory you will find my notes, a whiteboard, the challenge's details, a link to the code and it's tests. 
+# This is my collection of data structures, algorithms and code challenges. Please visit the [Table of Contents](./table_of_contents.md) to view all the categories. Within each category you will find my notes, a whiteboard, the challenge's details, a link to the code and its tests. 
 
 --------------------------
 
-## 💡 I have a short list of [helpful resources](./resources.md) I use while working in this repo. Check it out! 
+## 💡 I have a short list of [helpful resources](./resources.md) I used while working in this repo. Check it out! 
 
 -------------------------
 

--- a/table_of_contents.md
+++ b/table_of_contents.md
@@ -33,7 +33,6 @@
 
   - [Challenge Description](./data_structures_and_algorithms/code_challenges/array_shift/array_shift_README.md) 
   - [Notes](./notes/array_shift_notes.md)
-  - [Whiteboard](./whiteboards/array_shift.jpeg)
   - [Code Implementation](./data_structures_and_algorithms/code_challenges/array_shift/array_shift.py)
   - [Tests](./tests/test_array_shift.py)
 
@@ -43,7 +42,6 @@
 
   - [Challenge Description](./data_structures_and_algorithms/data_structures/linked_lists/linked_lists_README.md) 
   - [Notes](./notes/linked_lists_notes.md)
-  - [Whiteboard](./whiteboards/linked_lists.jpeg)
   - [Code Implementation](./data_structures_and_algorithms/data_structures/linked_lists/linked_lists.py)
   - [Tests](./tests/test_linked_lists.py)
 
@@ -53,7 +51,6 @@
 
   - [Challenge Description](./data_structures_and_algorithms/data_structures/trees/trees_README.md) 
   - [Notes](./notes/trees_notes.md)
-  - [Whiteboard](./whiteboards/trees.jpeg)
   - [Code Implementation](./data_structures_and_algorithms/data_structures/trees/trees.py)
   - [Tests](./tests/test_trees.py)
 


### PR DESCRIPTION
- Eliminates a number of typographical errors on the main readme.
- Fixes #18 by eliminating Whiteboard links entirely. Repairing links would likely be ideal, however.